### PR TITLE
Explicit ICA classification method mapping

### DIFF
--- a/src/lib/fileGeneration.ts
+++ b/src/lib/fileGeneration.ts
@@ -237,10 +237,13 @@ export function generateTaskScript(config: ConfigType): string {
     }
     
     // Handle ICA component classification method
-    let icaClassificationCode = 'self.classify_ica_components()';
-    
-    if (taskData.settings?.component_rejection?.enabled && taskData.settings.component_rejection.method === 'icvision') {
-      icaClassificationCode = "self.classify_ica_components(method='icvision')";
+    let icaClassificationCode = '# ICA component classification skipped';
+
+    if (taskData.settings?.component_rejection?.enabled) {
+      const method = taskData.settings.component_rejection.method;
+      if (method === 'iclabel' || method === 'icvision') {
+        icaClassificationCode = `self.classify_ica_components(method='${method}')`;
+      }
     }
     
     // Replace template placeholders


### PR DESCRIPTION
## Summary
- Map component rejection methods to explicit `self.classify_ica_components` calls for supported options.
- Skip ICA component classification when component rejection is disabled.

## Testing
- `npm run lint` *(fails: multiple existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ba033c1260832290482e7bde88923c