### PR TITLE
feat: add ICA rejection overrides and PSD limit

### DIFF
--- a/src/components/KeyValueEditor.tsx
+++ b/src/components/KeyValueEditor.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Plus, X } from 'lucide-react';
+
+interface KeyValueEditorProps {
+  value: Record<string, number>;
+  onChange: (value: Record<string, number>) => void;
+  className?: string;
+}
+
+const KeyValueEditor: React.FC<KeyValueEditorProps> = ({ value = {}, onChange, className = '' }) => {
+  const [entries, setEntries] = useState<[string, number][]>(Object.entries(value));
+
+  const updateEntries = (newEntries: [string, number][]) => {
+    setEntries(newEntries);
+    const obj: Record<string, number> = {};
+    newEntries.forEach(([k, v]) => {
+      if (k.trim() !== '' && !isNaN(v)) {
+        obj[k] = v;
+      }
+    });
+    onChange(obj);
+  };
+
+  const addEntry = () => {
+    updateEntries([...entries, ['', 0]]);
+  };
+
+  const updateKey = (index: number, key: string) => {
+    const newEntries = [...entries];
+    newEntries[index] = [key, newEntries[index][1]];
+    updateEntries(newEntries);
+  };
+
+  const updateValue = (index: number, value: number) => {
+    const newEntries = [...entries];
+    newEntries[index] = [newEntries[index][0], value];
+    updateEntries(newEntries);
+  };
+
+  const removeEntry = (index: number) => {
+    const newEntries = entries.filter((_, i) => i !== index);
+    updateEntries(newEntries);
+  };
+
+  return (
+    <div className={`space-y-2 ${className}`}>
+      {entries.map(([k, v], idx) => (
+        <div key={idx} className="flex gap-2 items-center">
+          <Input
+            value={k}
+            onChange={(e) => updateKey(idx, e.target.value)}
+            placeholder="Component type"
+            className="flex-1"
+          />
+          <Input
+            type="number"
+            value={v}
+            onChange={(e) => updateValue(idx, parseFloat(e.target.value))}
+            placeholder="0-1"
+            className="w-24"
+          />
+          <Button type="button" variant="ghost" size="icon" onClick={() => removeEntry(idx)}>
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      ))}
+      <Button type="button" variant="secondary" size="sm" onClick={addEntry} className="mt-1">
+        <Plus className="h-4 w-4 mr-1" /> Add Override
+      </Button>
+    </div>
+  );
+};
+
+export default KeyValueEditor;

--- a/src/components/KeyValueEditor.tsx
+++ b/src/components/KeyValueEditor.tsx
@@ -1,7 +1,18 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Plus, X } from 'lucide-react';
+
+// Available IC component types that can have thresholds overridden
+const IC_COMPONENT_OPTIONS = [
+  { value: 'muscle', label: 'Muscle' },
+  { value: 'eog', label: 'EOG/Eye' },
+  { value: 'heart', label: 'Heart' },
+  { value: 'line_noise', label: 'Line Noise' },
+  { value: 'ch_noise', label: 'Channel Noise' },
+  { value: 'brain', label: 'Brain' }, // Brain is included as it can also have a threshold
+];
 
 interface KeyValueEditorProps {
   value: Record<string, number>;
@@ -11,6 +22,11 @@ interface KeyValueEditorProps {
 
 const KeyValueEditor: React.FC<KeyValueEditorProps> = ({ value = {}, onChange, className = '' }) => {
   const [entries, setEntries] = useState<[string, number][]>(Object.entries(value));
+
+  // Sync entries with external value prop changes
+  useEffect(() => {
+    setEntries(Object.entries(value));
+  }, [value]);
 
   const updateEntries = (newEntries: [string, number][]) => {
     setEntries(newEntries);
@@ -24,7 +40,13 @@ const KeyValueEditor: React.FC<KeyValueEditorProps> = ({ value = {}, onChange, c
   };
 
   const addEntry = () => {
-    updateEntries([...entries, ['', 0]]);
+    // Find the first component type that hasn't been used yet
+    const usedTypes = entries.map(([k]) => k);
+    const availableType = IC_COMPONENT_OPTIONS.find(opt => !usedTypes.includes(opt.value));
+    
+    if (availableType) {
+      updateEntries([...entries, [availableType.value, 0.5]]);
+    }
   };
 
   const updateKey = (index: number, key: string) => {
@@ -44,31 +66,54 @@ const KeyValueEditor: React.FC<KeyValueEditorProps> = ({ value = {}, onChange, c
     updateEntries(newEntries);
   };
 
+  // Get available options for a given entry (exclude already selected types)
+  const getAvailableOptions = (currentKey: string) => {
+    const usedTypes = entries.map(([k]) => k).filter(k => k !== currentKey);
+    return IC_COMPONENT_OPTIONS.filter(opt => !usedTypes.includes(opt.value));
+  };
+
+  // Check if we can add more entries
+  const canAddMore = entries.length < IC_COMPONENT_OPTIONS.length;
+
   return (
     <div className={`space-y-2 ${className}`}>
       {entries.map(([k, v], idx) => (
         <div key={idx} className="flex gap-2 items-center">
-          <Input
+          <Select
             value={k}
-            onChange={(e) => updateKey(idx, e.target.value)}
-            placeholder="Component type"
-            className="flex-1"
-          />
+            onValueChange={(value) => updateKey(idx, value)}
+          >
+            <SelectTrigger className="flex-1">
+              <SelectValue placeholder="Select component type" />
+            </SelectTrigger>
+            <SelectContent>
+              {getAvailableOptions(k).map(option => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
           <Input
             type="number"
             value={v}
             onChange={(e) => updateValue(idx, parseFloat(e.target.value))}
             placeholder="0-1"
             className="w-24"
+            step="0.1"
+            min="0"
+            max="1"
           />
           <Button type="button" variant="ghost" size="icon" onClick={() => removeEntry(idx)}>
             <X className="h-4 w-4" />
           </Button>
         </div>
       ))}
-      <Button type="button" variant="secondary" size="sm" onClick={addEntry} className="mt-1">
-        <Plus className="h-4 w-4 mr-1" /> Add Override
-      </Button>
+      {canAddMore && (
+        <Button type="button" variant="secondary" size="sm" onClick={addEntry} className="mt-1">
+          <Plus className="h-4 w-4 mr-1" /> Add Override
+        </Button>
+      )}
     </div>
   );
 };

--- a/src/components/steps/Step7ICA.tsx
+++ b/src/components/steps/Step7ICA.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
-import FormField from '../FormField'; 
+import FormField from '../FormField';
+import KeyValueEditor from '@/components/KeyValueEditor';
 import { AnimatedSection } from '@/components/AnimatedSection';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import type { TaskData, ValidationErrors } from '@/lib/types';
@@ -186,31 +187,63 @@ const Step7ICA: React.FC<Step7Props> = ({
                                 </p>
                             )}
                         </div>
-                        <div className="grid md:grid-cols-2 gap-4">
-                            <FormField
-                                path={`tasks.${currentTaskName}.settings.component_rejection.value.ic_rejection_threshold`}
-                                label="Rejection Threshold"
-                                tooltip="Threshold for automatic component rejection (0-1)"
-                                value={componentRejectionSettings.value?.ic_rejection_threshold}
-                                onChange={handleInputChange}
-                                error={errors[`tasks.${currentTaskName}.settings.component_rejection.value.ic_rejection_threshold`]}
-                                type="number"
-                                placeholder="e.g., 0.3"
-                            />
-                            <FormField
-                                path={`tasks.${currentTaskName}.settings.component_rejection.method`}
-                                label="Classification Method"
-                                tooltip="Method for component classification: ICLabel (default) or ICVision"
-                                value={componentRejectionSettings.method || 'iclabel'}
-                                onChange={handleInputChange}
-                                error={errors[`tasks.${currentTaskName}.settings.component_rejection.method`]}
-                                type="select"
-                                options={[
-                                    { value: "iclabel", label: "ICLabel" },
-                                    { value: "icvision", label: "ICVision" }
-                                ]}
-                                placeholder="Select method..."
-                            />
+                        <div className="space-y-4">
+                            <div className="space-y-2">
+                                <Label className="text-sm font-medium">IC Rejection Overrides</Label>
+                                <p className="text-xs text-muted-foreground">
+                                    Override thresholds for specific component types
+                                </p>
+                                <KeyValueEditor
+                                    value={componentRejectionSettings.value?.ic_rejection_overrides || {}}
+                                    onChange={(val) =>
+                                        handleInputChange(
+                                            `tasks.${currentTaskName}.settings.component_rejection.value.ic_rejection_overrides`,
+                                            val
+                                        )
+                                    }
+                                />
+                                {errors[`tasks.${currentTaskName}.settings.component_rejection.value.ic_rejection_overrides`] && (
+                                    <p className="text-sm text-red-500">
+                                        {errors[`tasks.${currentTaskName}.settings.component_rejection.value.ic_rejection_overrides`]}
+                                    </p>
+                                )}
+                            </div>
+                            <div className="grid md:grid-cols-2 gap-4">
+                                <FormField
+                                    path={`tasks.${currentTaskName}.settings.component_rejection.value.ic_rejection_threshold`}
+                                    label="Rejection Threshold"
+                                    tooltip="Threshold for automatic component rejection (0-1)"
+                                    value={componentRejectionSettings.value?.ic_rejection_threshold}
+                                    onChange={handleInputChange}
+                                    error={errors[`tasks.${currentTaskName}.settings.component_rejection.value.ic_rejection_threshold`]}
+                                    type="number"
+                                    placeholder="e.g., 0.3"
+                                />
+                                <FormField
+                                    path={`tasks.${currentTaskName}.settings.component_rejection.value.psd_fmax`}
+                                    label="PSD Max Frequency"
+                                    tooltip="Maximum frequency for PSD estimation"
+                                    value={componentRejectionSettings.value?.psd_fmax}
+                                    onChange={handleInputChange}
+                                    error={errors[`tasks.${currentTaskName}.settings.component_rejection.value.psd_fmax`]}
+                                    type="number"
+                                    placeholder="e.g., 50"
+                                />
+                                <FormField
+                                    path={`tasks.${currentTaskName}.settings.component_rejection.method`}
+                                    label="Classification Method"
+                                    tooltip="Method for component classification: ICLabel (default) or ICVision"
+                                    value={componentRejectionSettings.method || 'iclabel'}
+                                    onChange={handleInputChange}
+                                    error={errors[`tasks.${currentTaskName}.settings.component_rejection.method`]}
+                                    type="select"
+                                    options={[
+                                        { value: "iclabel", label: "ICLabel" },
+                                        { value: "icvision", label: "ICVision" }
+                                    ]}
+                                    placeholder="Select method..."
+                                />
+                            </div>
                         </div>
                     </AnimatedSection>
                 )}

--- a/src/components/steps/Step7ICA.tsx
+++ b/src/components/steps/Step7ICA.tsx
@@ -51,13 +51,13 @@ const Step7ICA: React.FC<Step7Props> = ({
     
     // Set appropriate fit_params based on method
     if (path.includes('method')) {
-      if (value === 'picard') {
+      if (value === 'infomax') {
         handleInputChange(`tasks.${currentTaskName}.settings.ICA.value.fit_params`, {
-          ortho: false,
           extended: true
         });
-      } else if (value === 'infomax') {
+      } else if (value === 'picard') {
         handleInputChange(`tasks.${currentTaskName}.settings.ICA.value.fit_params`, {
+          ortho: false,
           extended: true
         });
       } else {
@@ -100,9 +100,9 @@ const Step7ICA: React.FC<Step7Props> = ({
                                 error={errors[`tasks.${currentTaskName}.settings.ICA.value.method`]}
                                 type="select"
                                 options={[
+                                    { value: "infomax", label: "Infomax" },
                                     { value: "picard", label: "Picard" },
-                                    { value: "fastica", label: "FastICA" },
-                                    { value: "infomax", label: "Infomax" }
+                                    { value: "fastica", label: "FastICA" }
                                 ]}
                                 placeholder="Select ICA method..."
                             />

--- a/src/components/steps/Step9Configure.tsx
+++ b/src/components/steps/Step9Configure.tsx
@@ -5,11 +5,14 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
 
 // Import local components and types
 import RejectionPolicySection from '@/components/RejectionPolicySection'; // Adjust path if needed
 import { TaskData, ValidationErrors } from '@/lib/types'; // Adjust path as needed
 import { designSystem, cn } from '@/lib/design-system';
+import { AnimatedSection } from '@/components/AnimatedSection';
 
 // Define the props interface
 interface Step9Props {
@@ -39,9 +42,45 @@ const Step9Configure: React.FC<Step9Props> = ({
         return null; // Or render an error/loading state
     }
 
+    const moveFlaggedFilesSettings = taskData.settings?.move_flagged_files;
+
     return (
         <> 
-            {/* Configuration Complete - No rejection policy needed in new structure */}
+            {/* File Management Options */}
+            <Card className={designSystem.card.container}>
+                <CardHeader className={cn(designSystem.card.header, "bg-gradient-to-r from-indigo-50 to-purple-50")}>
+                    <CardTitle className={designSystem.card.title}>File Management</CardTitle>
+                    <CardDescription className={designSystem.card.description}>Configure how flagged files should be handled during processing.</CardDescription>
+                </CardHeader>
+                <CardContent className={cn("space-y-4", designSystem.card.content)}>
+                    <AnimatedSection
+                        title="Move Flagged Files"
+                        description="Automatically move files that are flagged as bad to a separate directory"
+                        enabled={moveFlaggedFilesSettings?.enabled || false}
+                        onToggle={() => handleInputChange(`tasks.${currentTaskName}.settings.move_flagged_files.enabled`, !moveFlaggedFilesSettings?.enabled)}
+                        contentClassName="pl-8 pt-3 pb-1 space-y-4 border-l-2 border-indigo-200 ml-2.5"
+                        color="indigo"
+                    >
+                        <div className="flex items-center space-x-3">
+                            <Switch
+                                id="move-flagged-value"
+                                checked={moveFlaggedFilesSettings?.value || false}
+                                onCheckedChange={(checked) => 
+                                    handleInputChange(`tasks.${currentTaskName}.settings.move_flagged_files.value`, checked)
+                                }
+                            />
+                            <Label htmlFor="move-flagged-value" className="text-sm">
+                                Move flagged files to 'bad' subdirectory
+                            </Label>
+                        </div>
+                        <p className="text-xs text-muted-foreground mt-2">
+                            When enabled, files that fail quality checks will be automatically moved to a 'bad' subdirectory 
+                            instead of being processed further. This helps keep your data organized and prevents bad files 
+                            from affecting downstream analyses.
+                        </p>
+                    </AnimatedSection>
+                </CardContent>
+            </Card>
             
             {/* Preview & Download Section */}
             <Card className={cn(designSystem.card.container, "mt-6")}>

--- a/src/lib/configTemplates.ts
+++ b/src/lib/configTemplates.ts
@@ -45,6 +45,8 @@ export const defaultTaskSettings: TaskData = {
       value: {
         ic_flags_to_reject: ["muscle", "heart", "eog", "ch_noise", "line_noise"],
         ic_rejection_threshold: 0.3,
+        ic_rejection_overrides: {},
+        psd_fmax: 50,
       },
     },
     epoch_settings: {
@@ -101,6 +103,8 @@ export const taskTemplates: Record<string, TaskData> = {
         value: {
           ic_flags_to_reject: ["muscle", "heart", "eog", "ch_noise", "line_noise"],
           ic_rejection_threshold: 0.3,
+          ic_rejection_overrides: {},
+          psd_fmax: 50,
         },
       },
       epoch_settings: {
@@ -154,6 +158,8 @@ export const taskTemplates: Record<string, TaskData> = {
         value: {
           ic_flags_to_reject: ["muscle", "heart", "eog", "ch_noise", "line_noise"],
           ic_rejection_threshold: 0.3,
+          ic_rejection_overrides: {},
+          psd_fmax: 50,
         },
       },
       epoch_settings: {

--- a/src/lib/configTemplates.ts
+++ b/src/lib/configTemplates.ts
@@ -55,6 +55,7 @@ export const defaultTaskSettings: TaskData = {
       remove_baseline: { enabled: false, window: [null, 0] },
       threshold_rejection: { enabled: false, volt_threshold: { eeg: 125e-6 } },
     },
+    move_flagged_files: { enabled: false, value: false },
   },
 };
 
@@ -112,6 +113,7 @@ export const taskTemplates: Record<string, TaskData> = {
         remove_baseline: { enabled: false, window: [null, 0] },
         threshold_rejection: { enabled: false, volt_threshold: { eeg: 125e-6 } },
       },
+      move_flagged_files: { enabled: false, value: false },
     },
   },
   EventBased: {
@@ -166,6 +168,7 @@ export const taskTemplates: Record<string, TaskData> = {
         remove_baseline: { enabled: false, window: [null, 0] },
         threshold_rejection: { enabled: false, volt_threshold: { eeg: 125e-6 } },
       },
+      move_flagged_files: { enabled: false, value: false },
     },
   },
 };

--- a/src/lib/configTemplates.ts
+++ b/src/lib/configTemplates.ts
@@ -31,10 +31,9 @@ export const defaultTaskSettings: TaskData = {
     ICA: {
       enabled: true,
       value: {
-        method: "picard",
+        method: "infomax",
         n_components: null,
         fit_params: {
-          ortho: false,
           extended: true,
         },
       },
@@ -89,10 +88,9 @@ export const taskTemplates: Record<string, TaskData> = {
       ICA: {
         enabled: true,
         value: {
-          method: "picard",
+          method: "infomax",
           n_components: null,
           fit_params: {
-            ortho: false,
             extended: true,
           },
         },
@@ -144,10 +142,9 @@ export const taskTemplates: Record<string, TaskData> = {
       ICA: {
         enabled: true,
         value: {
-          method: "picard",
+          method: "infomax",
           n_components: null,
           fit_params: {
-            ortho: false,
             extended: true,
           },
         },

--- a/src/lib/fileGeneration.ts
+++ b/src/lib/fileGeneration.ts
@@ -108,7 +108,8 @@ export const prepareConfigForPython = (configToPrepare: ConfigType): Record<stri
             'settings.epoch_settings.value.tmin',
             'settings.epoch_settings.value.tmax',
             'settings.epoch_settings.threshold_rejection.volt_threshold.eeg',
-            'settings.component_rejection.value.ic_rejection_threshold'
+            'settings.component_rejection.value.ic_rejection_threshold',
+            'settings.component_rejection.value.psd_fmax'
         ];
 
         numericPaths.forEach(fieldPath => {
@@ -128,6 +129,19 @@ export const prepareConfigForPython = (configToPrepare: ConfigType): Record<stri
                 }
             } catch (e) { /* Ignore */ }
         });
+
+        // Ensure ic_rejection_overrides values are numbers
+        try {
+            const overrides = taskData.settings?.component_rejection?.value?.ic_rejection_overrides;
+            if (overrides && typeof overrides === 'object') {
+                Object.keys(overrides).forEach((key) => {
+                    const num = parseFloat((overrides as any)[key]);
+                    if (!isNaN(num)) {
+                        (overrides as any)[key] = num;
+                    }
+                });
+            }
+        } catch (e) { /* Ignore */ }
 
         // Handle event_id - convert array of event IDs to dict or keep as null
         try {

--- a/src/lib/pythonParser.ts
+++ b/src/lib/pythonParser.ts
@@ -163,10 +163,14 @@ function convertPythonConfigToTaskSettings(configObj: any): TaskSettings {
           enabled: value.enabled || false,
           method: value.method || 'iclabel',
           value: {
-            ic_flags_to_reject: Array.isArray(value.value?.ic_flags_to_reject) 
-              ? value.value.ic_flags_to_reject 
+            ic_flags_to_reject: Array.isArray(value.value?.ic_flags_to_reject)
+              ? value.value.ic_flags_to_reject
               : [],
-            ic_rejection_threshold: value.value?.ic_rejection_threshold || 0.8
+            ic_rejection_threshold: value.value?.ic_rejection_threshold || 0.8,
+            ic_rejection_overrides: typeof value.value?.ic_rejection_overrides === 'object'
+              ? value.value.ic_rejection_overrides
+              : {},
+            psd_fmax: value.value?.psd_fmax
           }
         };
         break;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -73,6 +73,7 @@ export interface TaskSettings {
     ICA?: StepConfig & { value: ICAValue };
     component_rejection?: StepConfig & { value: ComponentRejectionValue; method: 'iclabel' | 'icvision' };
     epoch_settings?: EpochSettings;
+    move_flagged_files?: StepConfig & { value: boolean };
     [key: string]: any; // Allow other potential settings
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -29,6 +29,8 @@ export interface ICAValue {
 export interface ComponentRejectionValue {
   ic_flags_to_reject: string[];
   ic_rejection_threshold: number;
+  ic_rejection_overrides?: Record<string, number>;
+  psd_fmax?: number;
 }
 
 // Nested structures within EpochSettings

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -85,9 +85,20 @@ export const validateConfig = (configToValidate: ConfigType): ValidationErrors =
       if (taskData.settings.component_rejection?.enabled && taskData.settings.component_rejection.value) {
           const componentRejection = taskData.settings.component_rejection.value;
           const componentRejectionPath = `${settingsPath}.component_rejection.value`;
-          
+
           if (componentRejection.ic_rejection_threshold < 0 || componentRejection.ic_rejection_threshold > 1) {
               errors[`${componentRejectionPath}.ic_rejection_threshold`] = 'IC rejection threshold must be between 0 and 1.';
+          }
+          if (componentRejection.ic_rejection_overrides) {
+              const invalid = Object.values(componentRejection.ic_rejection_overrides).some(
+                  (v) => typeof v !== 'number' || v < 0 || v > 1
+              );
+              if (invalid) {
+                  errors[`${componentRejectionPath}.ic_rejection_overrides`] = 'Override values must be between 0 and 1.';
+              }
+          }
+          if (componentRejection.psd_fmax !== undefined && (isNaN(Number(componentRejection.psd_fmax)) || Number(componentRejection.psd_fmax) <= 0)) {
+              errors[`${componentRejectionPath}.psd_fmax`] = 'PSD fmax must be a positive number.';
           }
       }
 


### PR DESCRIPTION
## Summary
- support optional IC rejection overrides and PSD fmax in component rejection settings
- expose overrides editor and PSD max input in ICA step
- parse and generate these fields in config and Python conversion utilities

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, no-unused-vars, and no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_68ba045deb808322a1e37d956ae99fdc