### PR TITLE
Add provenance metadata export with timestamp

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -164,8 +164,9 @@ function App() {
                  current[parts[i]] = [null, null]; // Create the 'window' array
             } else if (parts[i] === 'volt_threshold' && parts[i-1] === 'threshold_rejection') {
                  current[parts[i]] = {}; // Create volt_threshold object
-            }
-             else {
+            } else if (parts[i] === 'provenance') {
+                 current[parts[i]] = {}; // Create provenance object
+            } else {
                 console.error(`Invalid path segment: ${parts[i]} in path ${path}`);
                 return prevConfig; // Avoid creating arbitrary objects for now
             }
@@ -274,21 +275,33 @@ function App() {
     }
 
     try {
+      // Stamp provenance timestamp
+      const timestamp = new Date().toISOString();
+      const updatedConfig = deepClone(config);
+      const taskName = getFirstTaskName(updatedConfig.tasks);
+      if (taskName) {
+        const task = updatedConfig.tasks[taskName];
+        if (!task.provenance) {
+          task.provenance = {};
+        }
+        task.provenance.timestamp = timestamp;
+      }
+
       // Generate Python task script content
-      const taskScriptContent = generateTaskScript(config);
-      
+      const taskScriptContent = generateTaskScript(updatedConfig);
+
       // Determine filename based on task name with a random 4-digit suffix for uniqueness
-      const taskName = getFirstTaskName(config.tasks);
       const suffix = Math.floor(Math.random() * 10000).toString().padStart(4, '0');
       const base = taskName ? taskName.toLowerCase() : 'task';
       const filename = `${base}-${suffix}.py`;
-      
+
       // Create blob and trigger download
       const blob = new Blob([taskScriptContent], { type: 'text/x-python' });
       saveAs(blob, filename);
-      
+
       // Update preview on successful download
       setPythonPreview(taskScriptContent);
+      setConfig(updatedConfig);
 
     } catch (error: any) {
       console.error("Python Generation/Download Error:", error);

--- a/src/components/steps/Step9Configure.tsx
+++ b/src/components/steps/Step9Configure.tsx
@@ -7,13 +7,12 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/com
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
+import FormField from '@/components/FormField';
 
 // Import local components and types
-import RejectionPolicySection from '@/components/RejectionPolicySection'; // Adjust path if needed
 import ArtifactFunctionDoc from '@/components/ArtifactFunctionDoc';
-import { TaskData, ValidationErrors } from '@/lib/types'; // Adjust path as needed
+import { TaskData, ValidationErrors } from '@/lib/types';
 import { designSystem, cn } from '@/lib/design-system';
-import { AnimatedSection } from '@/components/AnimatedSection';
 
 // Define the props interface
 interface Step9Props {
@@ -37,7 +36,7 @@ const Step9Configure: React.FC<Step9Props> = ({
     handleDownload,
     goToPreviousStep,
 }) => {
-    // Ensure taskData and rejection_policy exist if needed by RejectionPolicySection
+    // Ensure task data is available
     if (!taskData) {
         console.warn("Task data missing in Step9Configure");
         return null; // Or render an error/loading state
@@ -46,7 +45,7 @@ const Step9Configure: React.FC<Step9Props> = ({
     const moveFlaggedFiles = taskData.settings?.move_flagged_files || false;
 
     return (
-        <> 
+        <>
             {/* File Management Options */}
             <Card className={designSystem.card.container}>
                 <CardHeader className={cn(designSystem.card.header, "bg-gradient-to-r from-indigo-50 to-purple-50 dark:from-slate-900 dark:to-slate-800")}>
@@ -73,9 +72,32 @@ const Step9Configure: React.FC<Step9Props> = ({
                     </div>
                 </CardContent>
             </Card>
-            
+
+            {/* Provenance Metadata */}
+            <Card className={cn(designSystem.card.container, "mt-6")}> 
+                <CardHeader className={cn(designSystem.card.header, "bg-gradient-to-r from-blue-50 to-sky-50 dark:from-slate-900 dark:to-slate-800")}> 
+                    <CardTitle className={designSystem.card.title}>Provenance</CardTitle>
+                    <CardDescription className={designSystem.card.description}>Optional user metadata for audit trails.</CardDescription>
+                </CardHeader>
+                <CardContent className={cn("space-y-4", designSystem.card.content)}>
+                    <FormField
+                        path={`tasks.${currentTaskName}.provenance.user_name`}
+                        label="Name (optional)"
+                        value={taskData.provenance?.user_name || ''}
+                        onChange={handleInputChange}
+                    />
+                    <FormField
+                        path={`tasks.${currentTaskName}.provenance.user_email`}
+                        label="Email (optional)"
+                        value={taskData.provenance?.user_email || ''}
+                        onChange={handleInputChange}
+                        inputProps={{ type: 'email' }}
+                    />
+                </CardContent>
+            </Card>
+
             {/* Preview & Download Section */}
-            <Card className={cn(designSystem.card.container, "mt-6")}>
+            <Card className={cn(designSystem.card.container, "mt-6")}> 
                 <CardHeader className={cn(designSystem.card.header, "bg-gradient-to-r from-emerald-50 to-teal-50 dark:from-slate-900 dark:to-slate-800")}> 
                     <CardTitle className={designSystem.card.title}>Preview & Download</CardTitle>
                     <CardDescription className={designSystem.card.description}>Review your complete EEG preprocessing pipeline and generate the Python configuration file.</CardDescription>

--- a/src/lib/fileGeneration.ts
+++ b/src/lib/fileGeneration.ts
@@ -213,10 +213,19 @@ export function generateTaskScript(config: ConfigType): string {
     }
     
     const taskData = config.tasks[taskKey];
-    
+
     // Prepare the Python config dictionary
     const pythonConfig = prepareConfigForPython(config);
     const configDict = formatPythonDict(pythonConfig);
+
+    // Build provenance comment block
+    const prov = taskData.provenance || {};
+    const lines = [
+        prov.user_name ? `#   user: ${prov.user_name}` : null,
+        prov.user_email ? `#   email: ${prov.user_email}` : null,
+        prov.timestamp ? `#   timestamp: ${prov.timestamp}` : null,
+    ].filter(Boolean);
+    const provenanceBlock = lines.length ? `# provenance:\n${lines.join('\n')}\n` : '';
     
     // Generate class name
     let desiredClassName = taskData.task_name || taskKey;
@@ -263,6 +272,7 @@ export function generateTaskScript(config: ConfigType): string {
     
     // Replace template placeholders
     let scriptContent = taskScriptTemplate
+      .replace(/{{PROVENANCE_BLOCK}}/g, provenanceBlock)
       .replace(/{{TASK_DESCRIPTION}}/g, taskData.description || 'CUSTOM TASK')
       .replace(/{{CLASS_NAME}}/g, desiredClassName)
       .replace(/{{CONFIG_DICT}}/g, configDict)

--- a/src/lib/fileTemplates.ts
+++ b/src/lib/fileTemplates.ts
@@ -1,4 +1,4 @@
-export const taskScriptTemplate = `from autoclean.core.task import Task
+export const taskScriptTemplate = `{{PROVENANCE_BLOCK}}from autoclean.core.task import Task
 
 # =============================================================================
 #                     {{TASK_DESCRIPTION}} EEG PREPROCESSING CONFIGURATION

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -85,6 +85,12 @@ export interface TaskSettings {
     [key: string]: any; // Allow other potential settings
 }
 
+// Optional provenance metadata for audit trails
+export interface Provenance {
+    user_name?: string;
+    user_email?: string;
+    timestamp?: string;
+}
 
 // Structure for a single task configuration
 export interface TaskData {
@@ -93,6 +99,7 @@ export interface TaskData {
     dataset_name?: string;
     input_path?: string;
     settings?: TaskSettings;
+    provenance?: Provenance;
 }
 
 // Top-level configuration structure - now simplified for single Python file


### PR DESCRIPTION
## Summary
- collect optional user name and email at the end of the task wizard
- stamp an ISO-8601 timestamp and include provenance metadata when exporting task files
- support provenance metadata in configuration types and Python file generation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 86 problems)

------
https://chatgpt.com/codex/tasks/task_e_68bd64be05c883229e1b56ae58eb4d0e